### PR TITLE
Gralloc2: Allow invalid usage bits

### DIFF
--- a/libs/ui/Gralloc2.cpp
+++ b/libs/ui/Gralloc2.cpp
@@ -113,9 +113,8 @@ status_t Gralloc2Mapper::validateBufferDescriptorInfo(
     }
 
     if (descriptorInfo->usage & ~validUsageBits) {
-        ALOGE("buffer descriptor contains invalid usage bits 0x%" PRIx64,
+        ALOGW("buffer descriptor contains invalid usage bits 0x%" PRIx64,
               descriptorInfo->usage & ~validUsageBits);
-        return BAD_VALUE;
     }
     return NO_ERROR;
 }


### PR DESCRIPTION
08-15 16:59:23.135   325   353 E Gralloc2: buffer descriptor contains invalid usage bits 0x2000000
08-15 16:59:23.135   325   353 E GraphicBufferAllocator: Failed to allocate (1920 x 1080) layerCount 1 format 2141391876 usage 42002900: 3
08-15 16:59:23.135   325   353 E BufferQueueProducer: [SurfaceView - com.google.android.gallery3d/com.android.gallery3d.app.MovieActivity#0] dequeueBuffer: createGraphicBuffer failed
08-15 16:59:23.135   425  9850 E ACodec  : dequeueBuffer failed: NO_MEMORY(-12).

- Many older grallocs seem to be providing invalid usage bits, thus
  breaking video playback/decoding and similar functionality. Don't return
  errors if we come across invalid bits. Log a warning and continue.