### PR TITLE
Add vendor version for libgui

### DIFF
--- a/libs/gui/Android.bp
+++ b/libs/gui/Android.bp
@@ -30,12 +30,12 @@ cc_library_headers {
     min_sdk_version: "29",
 }
 
-cc_library_shared {
-    name: "libgui",
-    vendor_available: false,
-    vndk: {
-        enabled: true,
-    },
+cc_defaults {
+    name: "libgui_defaults",
+    
+
+
+
     double_loadable: true,
 
     defaults: ["libgui_bufferqueue-defaults"],
@@ -262,6 +262,23 @@ cc_library_static {
         "mock/GraphicBufferConsumer.cpp",
         "mock/GraphicBufferProducer.cpp",
     ],
+}
+
+	
+cc_library_shared {
+    name: "libgui",
+    vendor_available: false,
+    vndk: {
+        enabled: true,	
+    },
+    double_loadable: true,
+    defaults: ["libgui_defaults"]	
+}
+	
+cc_library_shared {
+    name: "libgui_vendor",
+    vendor: true,
+    defaults: ["libgui_defaults"]	
 }
 
 subdirs = ["tests"]


### PR DESCRIPTION
based on this commit: https://review.lineageos.org/c/LineageOS/android_frameworks_native/+/258316
Allows to build libgui_vendor